### PR TITLE
Color: use an extern struct to allow bitCasts + misc

### DIFF
--- a/src/engine.zig
+++ b/src/engine.zig
@@ -3,7 +3,7 @@ const gl = @import("gl");
 const glfw = @import("mach-glfw");
 const math = @import("mach").math;
 const c = @import("c.zig");
-const Color = @import("color.zig");
+const Color = @import("color.zig").Color;
 
 var instance: *Engine = undefined;
 


### PR DESCRIPTION
* use `@bitCast()` - to/fromVec() and toVec4() become trivial
* fromHex() - use fmt.hexToBytes() which is more efficient than fmt.parseInt().  also now does less branching.
* add vecFromScalar() method
* rename ColorV to f32x4, ByteColorV to u8x4.  i just thought this was easier to read.  happy to change the names back if you prefer.